### PR TITLE
Replace OpenTracing error logs with SignalFx tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,12 @@ target/
 # celery beat schedule file
 celerybeat-schedule
 
+# pytest
+.pytest_cache
+
+# vscode
+.vscode
+
 # dotenv
 .env
 

--- a/flask_opentracing/tracing.py
+++ b/flask_opentracing/tracing.py
@@ -154,10 +154,9 @@ class FlaskTracing(opentracing.Tracer):
             scope.span.set_tag(tags.HTTP_STATUS_CODE, response.status_code)
         if error is not None:
             scope.span.set_tag(tags.ERROR, True)
-            scope.span.log_kv({
-                'event': tags.ERROR,
-                'error.object': error,
-            })
+            scope.span.set_tag('sfx.error.message', str(error))
+            scope.span.set_tag('sfx.error.object', str(error.__class__))
+            scope.span.set_tag('sfx.error.kind', error.__class__.__name__)
 
         scope.close()
 


### PR DESCRIPTION
This PR changes how errors are recorded on spans. It uses the new SignalFx semantic convention and records the errors as attributes instead of logs.